### PR TITLE
Fix package references in package-info.java

### DIFF
--- a/src/main/java/nl/tudelft/planningstool/database/controllers/package-info.java
+++ b/src/main/java/nl/tudelft/planningstool/database/controllers/package-info.java
@@ -1,4 +1,4 @@
 /**
- * DAOs are used to connect to the database and to control {@link nl.tudelft.planningstool.database.entities}
+ * DAOs are used to connect to the database and to control <a href="{@docRoot}/nl/tudelft/planningstool/database/entities/package-summary.html#package_description">entities</a>.
  */
 package nl.tudelft.planningstool.database.controllers;

--- a/src/main/java/nl/tudelft/planningstool/database/embeddables/package-info.java
+++ b/src/main/java/nl/tudelft/planningstool/database/embeddables/package-info.java
@@ -1,4 +1,4 @@
 /**
- * Embeddables are used in {@link nl.tudelft.planningstool.database.entities entities}.
+ * Embeddables are used in <a href="{@docRoot}/nl/tudelft/planningstool/database/entities/package-summary.html#package_description">entities</a>.
  */
 package nl.tudelft.planningstool.database.embeddables;


### PR DESCRIPTION
The Javadoc generation tool complained about the references as it was never imported. A custom <a> fixes this issue.
